### PR TITLE
Fix privacy notice: preprint notifications, lowercase email

### DIFF
--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 
-<title>Privacy Notice for the Replication Preprint Bot Study – Making Replications Count</title>
+<title>Privacy Notice for the Replication Preprint Notifications Study – Making Replications Count</title>
 <style>
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
@@ -87,7 +87,7 @@ ul.task-list li input[type="checkbox"] {
 
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
-<h1 class="title">Privacy Notice for the Replication Preprint Bot Study</h1>
+<h1 class="title">Privacy Notice for the Replication Preprint Notifications Study</h1>
 </div>
 
 
@@ -111,7 +111,7 @@ ul.task-list li input[type="checkbox"] {
 <ul>
 <li>Address: Birkbeck College, Malet St, Bloomsbury, London, WC1E 7HX</li>
 <li>Data Protection Officer: <a href="mailto:dpo@bbk.ac.uk">dpo@bbk.ac.uk</a></li>
-<li>Data inquiries: <a href="mailto:L.wallrich@bbk.ac.uk">L.wallrich@bbk.ac.uk</a></li>
+<li>Data inquiries: <a href="mailto:l.wallrich@bbk.ac.uk">l.wallrich@bbk.ac.uk</a></li>
 </ul>
 </section>
 <section id="purpose-of-data-collection" class="level2">

--- a/privacy.qmd
+++ b/privacy.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Privacy Notice for the Replication Preprint Bot Study"
+title: "Privacy Notice for the Replication Preprint Notifications Study"
 ---
 
 ## Who Collects Data?
@@ -10,7 +10,7 @@ Birkbeck College (Birkbeck, University of London) serves as the data controller.
 
 - Address: Birkbeck College, Malet St, Bloomsbury, London, WC1E 7HX
 - Data Protection Officer: [dpo@bbk.ac.uk](mailto:dpo@bbk.ac.uk)
-- Data inquiries: [L.wallrich@bbk.ac.uk](mailto:L.wallrich@bbk.ac.uk)
+- Data inquiries: [l.wallrich@bbk.ac.uk](mailto:l.wallrich@bbk.ac.uk)
 
 ## Purpose of Data Collection
 


### PR DESCRIPTION
- "Preprint Bot" → "Preprint Notifications" in the title
- `L.wallrich@bbk.ac.uk` → `l.wallrich@bbk.ac.uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)